### PR TITLE
Update for Spring Boot 3.0.0-R1

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,23 +14,33 @@ The native image that I was able to create works (better than) as expected on a 
 ### Getting Started
 
 - Clone the repo.
-- Make sure that Java is installed, I've tested with Java 17
+- Currently, you need a local GraalVM 22.3 installation to build an image with Maven. This will be solved in the future, see [native-build-tools issue #327](https://github.com/graalvm/native-build-tools/issues/327) for details. If you have sdkman installed run: 
+```shell 
+sdk install java 22.3.r17.ea-nik
+```
 
 ### Generate Native ARM64
 ```shell
-./mvnw -Pnative-arm64 spring-boot:build-image -DskipTests
+./mvnw clean -Pnative,native-arm64 spring-boot:build-image -DskipTests
 ```
 
 ### Generate Native AMD64
 ```shell
-./mvnw -Pnative-amd64 spring-boot:build-image -DskipTests
+./mvnw clean -Pnative,native-amd64 spring-boot:build-image -DskipTests
 ```
 
 ### Generate image AMD64
 ```shell
-./mvnw spring-boot:build-image -DskipTests
+./mvnw clean -Pnative spring-boot:build-image -DskipTests
 ```
 
 Once complete, you should have a new image "spring-pi:0.0.1-SNAPSHOT" in your local registry.
 
+### If you are running this from behind a company firewall
+
+If you are running this from behind a company firewall, one that will rewrite every request, you'll need to add your company's CA certificate in a PEM format to the folder
+_bindings/ca-certificates_ . The certificate will be discovered by the _Paketo CA Certificates Buildpack_ and used accordingly.
+
 ### Feedback Welcome!
+
+Dashaun you're awesome!!!! AWESOME!!!

--- a/bindings/ca-certificates/type
+++ b/bindings/ca-certificates/type
@@ -1,0 +1,1 @@
+ca-certificates

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
   <parent>
     <groupId>org.springframework.boot</groupId>
     <artifactId>spring-boot-starter-parent</artifactId>
-    <version>2.6.4</version>
+    <version>3.0.0-RC1</version>
     <relativePath></relativePath>
     <!-- lookup parent from repository -->
   </parent>
@@ -16,46 +16,15 @@
   <properties>
     <java.version>17</java.version>
     <repackage.classifier></repackage.classifier>
-    <spring-native.version>0.11.2</spring-native.version>
   </properties>
   <dependencies>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-actuator</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>io.micrometer</groupId>
-          <artifactId>micrometer-core</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.boot</groupId>
-      <artifactId>spring-boot-starter-security</artifactId>
     </dependency>
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
-      <exclusions>
-        <exclusion>
-          <groupId>org.apache.tomcat.embed</groupId>
-          <artifactId>tomcat-embed-core</artifactId>
-        </exclusion>
-        <exclusion>
-          <groupId>org.apache.tomcat.embed</groupId>
-          <artifactId>tomcat-embed-websocket</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
-    <dependency>
-      <groupId>org.apache.tomcat.experimental</groupId>
-      <artifactId>tomcat-embed-programmatic</artifactId>
-      <version>${tomcat.version}</version>
-    </dependency>
-    <dependency>
-      <groupId>org.springframework.experimental</groupId>
-      <artifactId>spring-native</artifactId>
-      <version>${spring-native.version}</version>
     </dependency>
 
     <dependency>
@@ -65,6 +34,14 @@
     </dependency>
   </dependencies>
   <repositories>
+    <repository>
+      <id>spring-milestones</id>
+      <name>Spring Milestones</name>
+      <url>https://repo.spring.io/milestone</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </repository>
     <repository>
       <snapshots>
         <enabled>false</enabled>
@@ -83,6 +60,14 @@
       <name>Spring Releases</name>
       <url>https://repo.spring.io/release</url>
     </pluginRepository>
+    <pluginRepository>
+      <id>spring-milestones</id>
+      <name>Spring Milestones</name>
+      <url>https://repo.spring.io/milestone</url>
+      <snapshots>
+        <enabled>false</enabled>
+      </snapshots>
+    </pluginRepository>
   </pluginRepositories>
 
   <build>
@@ -93,31 +78,15 @@
         <configuration>
           <classifier>${repackage.classifier}</classifier>
           <image>
+            <bindings>
+              <binding>${project.basedir}/bindings/ca-certificates:/platform/bindings/ca-certificates</binding>
+            </bindings>
             <builder>paketobuildpacks/builder:tiny</builder>
             <env>
               <BP_NATIVE_IMAGE>false</BP_NATIVE_IMAGE>
             </env>
           </image>
         </configuration>
-      </plugin>
-      <plugin>
-        <groupId>org.springframework.experimental</groupId>
-        <artifactId>spring-aot-maven-plugin</artifactId>
-        <version>${spring-native.version}</version>
-        <executions>
-          <execution>
-            <id>test-generate</id>
-            <goals>
-              <goal>test-generate</goal>
-            </goals>
-          </execution>
-          <execution>
-            <id>generate</id>
-            <goals>
-              <goal>generate</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
     </plugins>
   </build>
@@ -126,7 +95,7 @@
     <profile>
       <id>native-arm64</id>
       <properties>
-        <native-buildtools.version>0.9.9</native-buildtools.version>
+        <native-buildtools.version>0.9.17</native-buildtools.version>
       </properties>
       <build>
         <plugins>
@@ -135,6 +104,9 @@
             <artifactId>spring-boot-maven-plugin</artifactId>
             <configuration>
               <image>
+                <bindings>
+                  <binding>${project.basedir}/bindings/ca-certificates:/platform/bindings/ca-certificates</binding>
+                </bindings>
                 <builder>dashaun/native-builder:focal-arm64</builder>
                 <env>
                   <BP_NATIVE_IMAGE>true</BP_NATIVE_IMAGE>
@@ -150,7 +122,7 @@
     <profile>
       <id>native-amd64</id>
       <properties>
-        <native-buildtools.version>0.9.9</native-buildtools.version>
+        <native-buildtools.version>0.9.17</native-buildtools.version>
       </properties>
       <build>
         <plugins>
@@ -159,6 +131,9 @@
             <artifactId>spring-boot-maven-plugin</artifactId>
             <configuration>
               <image>
+                <bindings>
+                  <binding>${project.basedir}/bindings/ca-certificates:/platform/bindings/ca-certificates</binding>
+                </bindings>
                 <builder>paketobuildpacks/builder:tiny</builder>
                 <env>
                   <BP_NATIVE_IMAGE>true</BP_NATIVE_IMAGE>


### PR DESCRIPTION
Hi Dashaun. First of all, thank you for creating this project! I have spent days looking for a way to create an arm64 docker image for my rpi cluster using paketo. Your example plus the builder you publish on Docker hub, based on Daniel Mikusa's work, made this possible. 
Since Spring Boot recently went R1 I wanted to see if I can update the example to work without the spring-native bits. And it works!!!!
I also added a config option for running this behind a corporate firewall, since I'm running this from my company issued MacbookPro M1. This also took a few hours of research. Let me know if you want to keep this in.

See you on the next Spring Office Hours :)